### PR TITLE
채널리스트 ExpandableCell 구현

### DIFF
--- a/BranchTalk.xcodeproj/project.pbxproj
+++ b/BranchTalk.xcodeproj/project.pbxproj
@@ -60,6 +60,9 @@
 		80CC39B02B44584C009E0818 /* SF-Pro.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 80CC39AF2B44584C009E0818 /* SF-Pro.ttf */; };
 		80D696DA2B55971F00C1761E /* HomeInitialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D696D92B55971F00C1761E /* HomeInitialViewModel.swift */; };
 		80F80CC62B5D5C760077654A /* ChannelFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F80CC52B5D5C760077654A /* ChannelFooterView.swift */; };
+		80F80CC92B5E4EF90077654A /* DmTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F80CC82B5E4EF90077654A /* DmTableViewCell.swift */; };
+		80F80CCB2B5E4F060077654A /* DmHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F80CCA2B5E4F060077654A /* DmHeaderView.swift */; };
+		80F80CCD2B5E4F120077654A /* DmFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F80CCC2B5E4F120077654A /* DmFooterView.swift */; };
 		80FFA2692B55712C00ED6995 /* ChannelTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FFA2682B55712C00ED6995 /* ChannelTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
@@ -108,6 +111,9 @@
 		80CC39AF2B44584C009E0818 /* SF-Pro.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SF-Pro.ttf"; sourceTree = "<group>"; };
 		80D696D92B55971F00C1761E /* HomeInitialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeInitialViewModel.swift; sourceTree = "<group>"; };
 		80F80CC52B5D5C760077654A /* ChannelFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelFooterView.swift; sourceTree = "<group>"; };
+		80F80CC82B5E4EF90077654A /* DmTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DmTableViewCell.swift; sourceTree = "<group>"; };
+		80F80CCA2B5E4F060077654A /* DmHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DmHeaderView.swift; sourceTree = "<group>"; };
+		80F80CCC2B5E4F120077654A /* DmFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DmFooterView.swift; sourceTree = "<group>"; };
 		80FFA2682B55712C00ED6995 /* ChannelTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -319,9 +325,20 @@
 			path = Util;
 			sourceTree = "<group>";
 		};
+		80F80CC72B5E4EE60077654A /* Dm */ = {
+			isa = PBXGroup;
+			children = (
+				80F80CC82B5E4EF90077654A /* DmTableViewCell.swift */,
+				80F80CCA2B5E4F060077654A /* DmHeaderView.swift */,
+				80F80CCC2B5E4F120077654A /* DmFooterView.swift */,
+			);
+			path = Dm;
+			sourceTree = "<group>";
+		};
 		80FFA2672B55710400ED6995 /* HomeInitial */ = {
 			isa = PBXGroup;
 			children = (
+				80F80CC72B5E4EE60077654A /* Dm */,
 				8020C9672B5999E200783221 /* Channel */,
 				807E3A9E2B4FAC4100587A33 /* HomeInitialViewController.swift */,
 				80D696D92B55971F00C1761E /* HomeInitialViewModel.swift */,
@@ -427,10 +444,13 @@
 			files = (
 				8047E84A2B4544020018254B /* RegisterViewController.swift in Sources */,
 				800ED5102B468041001A7ECC /* CustomLabel.swift in Sources */,
+				80F80CCD2B5E4F120077654A /* DmFooterView.swift in Sources */,
 				80802AA02B46E09E008F1723 /* HomeEmptyViewController.swift in Sources */,
 				80CC39762B4430BA009E0818 /* OnboardingViewController.swift in Sources */,
+				80F80CC92B5E4EF90077654A /* DmTableViewCell.swift in Sources */,
 				800A05572B5268F40010505A /* SideMenuViewController.swift in Sources */,
 				80F80CC62B5D5C760077654A /* ChannelFooterView.swift in Sources */,
+				80F80CCB2B5E4F060077654A /* DmHeaderView.swift in Sources */,
 				80FFA2692B55712C00ED6995 /* ChannelTableViewCell.swift in Sources */,
 				80CC39AA2B4440C8009E0818 /* CustomColor.swift in Sources */,
 				809CF0112B4C441200F7BC68 /* CommonError.swift in Sources */,

--- a/BranchTalk/Model/NetworkModel.swift
+++ b/BranchTalk/Model/NetworkModel.swift
@@ -82,7 +82,7 @@ struct GetChannel: Decodable, Hashable {
     }
 }
 
-struct GetDmList: Decodable {
+struct GetDmList: Decodable, Hashable {
     let workspaceID, roomID: Int
     let createdAt: String
     let user: User

--- a/BranchTalk/Network/Router.swift
+++ b/BranchTalk/Network/Router.swift
@@ -18,6 +18,7 @@ enum Router: URLRequestConvertible {
     case getWorkSpaceList
     case getMyProfile
     case getChannelList(id: Int)
+    case getDmList(id: Int)
     
     private var baseURL: URL {
         guard let url = URL(string: APIKey.baseURL) else { fatalError() }
@@ -28,7 +29,7 @@ enum Router: URLRequestConvertible {
         switch self {
         case .kakaoLogin, .emailValidate, .register, .makeWorkSpace:
                return .post
-        case .refresh, .getWorkSpaceList, .getMyProfile, .getChannelList:
+        case .refresh, .getWorkSpaceList, .getMyProfile, .getChannelList, .getDmList:
                return .get
         }
     }
@@ -51,6 +52,8 @@ enum Router: URLRequestConvertible {
             return "v1/users/my"
         case .getChannelList(let id):
             return "v1/workspaces/\(id)/channels"
+        case .getDmList(let id):
+            return "v1/workspaces/\(id)/dms"
         }
     }
     
@@ -68,7 +71,7 @@ enum Router: URLRequestConvertible {
                     "RefreshToken": KeyChain.shared.read(key: "refresh") ?? "",
                     "Authorization": KeyChain.shared.read(key: "access") ?? "",
                     "SesacKey": "\(APIKey.apiKey)"]
-        case .getWorkSpaceList, .getMyProfile, .getChannelList:
+        case .getWorkSpaceList, .getMyProfile, .getChannelList, .getDmList:
             return ["Content-Type": "application/json",
                     "Authorization": KeyChain.shared.read(key: "access")!,
                     "SesacKey": "\(APIKey.apiKey)"]
@@ -103,7 +106,7 @@ enum Router: URLRequestConvertible {
         }
         
         switch self {
-        case .makeWorkSpace, .getWorkSpaceList, .getMyProfile, .getChannelList:
+        case .makeWorkSpace, .getWorkSpaceList, .getMyProfile, .getChannelList, .getDmList:
             return try URLEncoding.default.encode(request, with: parameters)
         default:
             let jsonData = try? JSONSerialization.data(withJSONObject: parameters)

--- a/BranchTalk/View/WorkSpace/Main/HomeInitial/Channel/ChannelTableViewCell.swift
+++ b/BranchTalk/View/WorkSpace/Main/HomeInitial/Channel/ChannelTableViewCell.swift
@@ -30,6 +30,8 @@ class ChannelTableViewCell: UITableViewCell {
             contentView.addSubview($0)
         }
         
+        contentView.backgroundColor = Colors.BackgroundSecondary.CutsomColor
+        
         tagImage.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.size.equalTo(18)

--- a/BranchTalk/View/WorkSpace/Main/HomeInitial/Dm/DmFooterView.swift
+++ b/BranchTalk/View/WorkSpace/Main/HomeInitial/Dm/DmFooterView.swift
@@ -1,0 +1,8 @@
+//
+//  DmFooterView.swift
+//  BranchTalk
+//
+//  Created by 황인호 on 1/22/24.
+//
+
+import Foundation

--- a/BranchTalk/View/WorkSpace/Main/HomeInitial/Dm/DmHeaderView.swift
+++ b/BranchTalk/View/WorkSpace/Main/HomeInitial/Dm/DmHeaderView.swift
@@ -1,17 +1,17 @@
 //
-//  ChannelHeaderView.swift
+//  DmHeaderView.swift
 //  BranchTalk
 //
-//  Created by 황인호 on 1/19/24.
+//  Created by 황인호 on 1/22/24.
 //
 
 import UIKit
 
-final class ChannelHeaderView: UITableViewHeaderFooterView {
+final class DmHeaderView: UITableViewHeaderFooterView {
     
     private let headerTitle = {
         let lb = CustomTitle2Label()
-        lb.text = "채널"
+        lb.text = "다이렉트 메시지"
         return lb
     }()
     
@@ -26,8 +26,6 @@ final class ChannelHeaderView: UITableViewHeaderFooterView {
         super.init(reuseIdentifier: reuseIdentifier)
         contentView.addSubview(headerTitle)
         contentView.addSubview(arrowButton)
-        
-        contentView.backgroundColor = Colors.BackgroundSecondary.CutsomColor
         
         headerTitle.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
@@ -44,3 +42,4 @@ final class ChannelHeaderView: UITableViewHeaderFooterView {
         fatalError("init(coder:) has not been implemented")
     }
 }
+

--- a/BranchTalk/View/WorkSpace/Main/HomeInitial/Dm/DmTableViewCell.swift
+++ b/BranchTalk/View/WorkSpace/Main/HomeInitial/Dm/DmTableViewCell.swift
@@ -1,0 +1,56 @@
+//
+//  DmTableViewCell.swift
+//  BranchTalk
+//
+//  Created by 황인호 on 1/22/24.
+//
+
+import UIKit
+import Kingfisher
+
+class DmTableViewCell: UITableViewCell {
+    
+    let profileImage = {
+        let view = UIImageView()
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 4
+        return view
+    }()
+    
+    let dmName = {
+        let lb = CustomBodyLabel()
+        return lb
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setUI()
+    }
+  
+    private func setUI() {
+        [profileImage, dmName].forEach {
+            contentView.addSubview($0)
+        }
+        
+        profileImage.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalToSuperview().offset(14)
+            make.size.equalTo(24)
+        }
+        
+        dmName.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.leading.equalTo(profileImage.snp.trailing).offset(8)
+        }
+        
+    }
+    
+    func configure(imageURL: String, name: String) {
+        profileImage.kf.setImage(with: URL(string: APIKey.baseURL + "/v1" + imageURL))
+        dmName.text = name
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/BranchTalk/View/WorkSpace/Main/HomeInitial/HomeInitialViewController.swift
+++ b/BranchTalk/View/WorkSpace/Main/HomeInitial/HomeInitialViewController.swift
@@ -64,6 +64,7 @@ final class HomeInitialViewController: BaseViewController {
     private var dataSource: UITableViewDiffableDataSource<Section,Item>?
     
     private var isExpandable: Bool = true
+    private var arrowToggle:Bool = true
     
     private let viewModel = HomeInitialViewModel()
     
@@ -224,7 +225,7 @@ final class HomeInitialViewController: BaseViewController {
         
         if isExpandable {
             isExpandable = false
-            
+            arrowToggle = false
             var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
             snapshot.appendSections([.channel])
             
@@ -232,12 +233,13 @@ final class HomeInitialViewController: BaseViewController {
             
         } else {
             isExpandable = true
+            arrowToggle = true
             var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
             snapshot.appendSections([.channel])
-            dataSource?.apply(snapshot)
             
             let items = channelList.map { Item.channelList($0) }
             snapshot.appendItems(items, toSection: .channel)
+            
             dataSource?.apply(snapshot)
         }
         
@@ -248,14 +250,17 @@ extension HomeInitialViewController: UITableViewDelegate{
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         if section == 0 {
             let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: ChannelHeaderView.identifier) as? ChannelHeaderView
+            header?.arrowButton.setImage(UIImage(named: arrowToggle ? "right" : "down"), for: .normal)
+            header?.setNeedsLayout()
+            header?.layoutIfNeeded()
             let tapGesture = UITapGestureRecognizer()
             header?.addGestureRecognizer(tapGesture)
             tapGesture.rx.event
                 .asDriver()
                 .drive(with: self) { owner, _ in
+                    tableView.reloadData()
                     owner.headerTapped()
                 }.disposed(by: disposeBag)
-            
            return header
         } else { return UIView() }
         


### PR DESCRIPTION
# 작업내용 
- 채널 섹션 확장, 축소 기능 구현
- 헤더뷰에 있는 화살표 확장, 축소에 따라 다르게 설정

# 기술적인 도전

1. Diffable DataSource를 활용한 Expandable Cell 구현
  - 섹션이 펼쳐져 있으면 헤더를 탭했을 때 섹션만 추가 되도록 해주고 반대로 접혀 있었을 때 탭하면 섹션과 아이템이 같이 추가 되도록 구현했습니다.
```swift
private func headerTapped() {
       
        if isExpandable {
            isExpandable = false
            arrowToggle = false
            var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
            snapshot.appendSections([.channel])
            
            dataSource?.apply(snapshot)
            
        } else {
            isExpandable = true
            arrowToggle = true
            var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
            snapshot.appendSections([.channel])
            
            let items = channelList.map { Item.channelList($0) }
            snapshot.appendItems(items, toSection: .channel)
            
            dataSource?.apply(snapshot)
        }
    }
``` 

