### PR TITLE
이미지 업로드가 안 되는 현상 해결, 네트워크 구조체 수정

### DIFF
--- a/BranchTalk.xcodeproj/project.pbxproj
+++ b/BranchTalk.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		809CF0132B4D3CB200F7BC68 /* MultipartModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809CF0122B4D3CB200F7BC68 /* MultipartModel.swift */; };
 		80C16BF72B4FD3A400414D98 /* KFModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C16BF62B4FD3A400414D98 /* KFModifier.swift */; };
 		80C16BF92B5159D700414D98 /* ViewMove.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C16BF82B5159D700414D98 /* ViewMove.swift */; };
+		80C629782B61349C00CBFF97 /* toDateAndString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C629772B61349C00CBFF97 /* toDateAndString.swift */; };
 		80CC39722B4430BA009E0818 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC39712B4430BA009E0818 /* AppDelegate.swift */; };
 		80CC39742B4430BA009E0818 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC39732B4430BA009E0818 /* SceneDelegate.swift */; };
 		80CC39762B4430BA009E0818 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC39752B4430BA009E0818 /* OnboardingViewController.swift */; };
@@ -98,6 +99,7 @@
 		809CF0122B4D3CB200F7BC68 /* MultipartModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipartModel.swift; sourceTree = "<group>"; };
 		80C16BF62B4FD3A400414D98 /* KFModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KFModifier.swift; sourceTree = "<group>"; };
 		80C16BF82B5159D700414D98 /* ViewMove.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMove.swift; sourceTree = "<group>"; };
+		80C629772B61349C00CBFF97 /* toDateAndString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = toDateAndString.swift; sourceTree = "<group>"; };
 		80CC396E2B4430BA009E0818 /* BranchTalk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BranchTalk.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		80CC39712B4430BA009E0818 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		80CC39732B4430BA009E0818 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -243,6 +245,14 @@
 			path = SideMenu;
 			sourceTree = "<group>";
 		};
+		80C629762B61348A00CBFF97 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				80C629772B61349C00CBFF97 /* toDateAndString.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		80CC39652B4430BA009E0818 = {
 			isa = PBXGroup;
 			children = (
@@ -262,6 +272,7 @@
 		80CC39702B4430BA009E0818 /* BranchTalk */ = {
 			isa = PBXGroup;
 			children = (
+				80C629762B61348A00CBFF97 /* Extensions */,
 				80802A952B468B44008F1723 /* Base */,
 				800ED5092B464AC1001A7ECC /* Model */,
 				802DB5122B4518CD004A5C47 /* Custom */,
@@ -463,6 +474,7 @@
 				80C16BF92B5159D700414D98 /* ViewMove.swift in Sources */,
 				802837CB2B4BDE32004CB167 /* CreateWorkSpaceViewModel.swift in Sources */,
 				80CC39722B4430BA009E0818 /* AppDelegate.swift in Sources */,
+				80C629782B61349C00CBFF97 /* toDateAndString.swift in Sources */,
 				80CC39A82B443FE0009E0818 /* APIKey.swift in Sources */,
 				802837C92B4BDE20004CB167 /* CreateWorkSpaceViewController.swift in Sources */,
 				80802A9D2B46CDAC008F1723 /* KeyChain.swift in Sources */,

--- a/BranchTalk.xcodeproj/project.pbxproj
+++ b/BranchTalk.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		80C16BF92B5159D700414D98 /* ViewMove.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C16BF82B5159D700414D98 /* ViewMove.swift */; };
 		80C629782B61349C00CBFF97 /* toDateAndString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C629772B61349C00CBFF97 /* toDateAndString.swift */; };
 		80C6297B2B61350900CBFF97 /* WorkSpaceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6297A2B61350900CBFF97 /* WorkSpaceList.swift */; };
+		80C6297D2B61374B00CBFF97 /* MyInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6297C2B61374B00CBFF97 /* MyInfo.swift */; };
+		80C6297F2B6138D000CBFF97 /* GetDmList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6297E2B6138D000CBFF97 /* GetDmList.swift */; };
 		80CC39722B4430BA009E0818 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC39712B4430BA009E0818 /* AppDelegate.swift */; };
 		80CC39742B4430BA009E0818 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC39732B4430BA009E0818 /* SceneDelegate.swift */; };
 		80CC39762B4430BA009E0818 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC39752B4430BA009E0818 /* OnboardingViewController.swift */; };
@@ -102,6 +104,8 @@
 		80C16BF82B5159D700414D98 /* ViewMove.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMove.swift; sourceTree = "<group>"; };
 		80C629772B61349C00CBFF97 /* toDateAndString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = toDateAndString.swift; sourceTree = "<group>"; };
 		80C6297A2B61350900CBFF97 /* WorkSpaceList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkSpaceList.swift; sourceTree = "<group>"; };
+		80C6297C2B61374B00CBFF97 /* MyInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInfo.swift; sourceTree = "<group>"; };
+		80C6297E2B6138D000CBFF97 /* GetDmList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDmList.swift; sourceTree = "<group>"; };
 		80CC396E2B4430BA009E0818 /* BranchTalk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BranchTalk.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		80CC39712B4430BA009E0818 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		80CC39732B4430BA009E0818 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -259,6 +263,8 @@
 			isa = PBXGroup;
 			children = (
 				80C6297A2B61350900CBFF97 /* WorkSpaceList.swift */,
+				80C6297C2B61374B00CBFF97 /* MyInfo.swift */,
+				80C6297E2B6138D000CBFF97 /* GetDmList.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -469,6 +475,7 @@
 				80F80CCD2B5E4F120077654A /* DmFooterView.swift in Sources */,
 				80802AA02B46E09E008F1723 /* HomeEmptyViewController.swift in Sources */,
 				80CC39762B4430BA009E0818 /* OnboardingViewController.swift in Sources */,
+				80C6297F2B6138D000CBFF97 /* GetDmList.swift in Sources */,
 				80C6297B2B61350900CBFF97 /* WorkSpaceList.swift in Sources */,
 				80F80CC92B5E4EF90077654A /* DmTableViewCell.swift in Sources */,
 				800A05572B5268F40010505A /* SideMenuViewController.swift in Sources */,
@@ -492,6 +499,7 @@
 				80802A9D2B46CDAC008F1723 /* KeyChain.swift in Sources */,
 				800A05552B5265AD0010505A /* HomeSideMenuNavigation.swift in Sources */,
 				80802AA52B471013008F1723 /* RegisterViewModel.swift in Sources */,
+				80C6297D2B61374B00CBFF97 /* MyInfo.swift in Sources */,
 				8007410C2B4EE07500CCB95C /* Interceptor.swift in Sources */,
 				8047E84E2B456B940018254B /* CustomRegisterTextField.swift in Sources */,
 				802DB5142B451903004A5C47 /* CustonButton.swift in Sources */,

--- a/BranchTalk.xcodeproj/project.pbxproj
+++ b/BranchTalk.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		80C16BF72B4FD3A400414D98 /* KFModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C16BF62B4FD3A400414D98 /* KFModifier.swift */; };
 		80C16BF92B5159D700414D98 /* ViewMove.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C16BF82B5159D700414D98 /* ViewMove.swift */; };
 		80C629782B61349C00CBFF97 /* toDateAndString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C629772B61349C00CBFF97 /* toDateAndString.swift */; };
+		80C6297B2B61350900CBFF97 /* WorkSpaceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C6297A2B61350900CBFF97 /* WorkSpaceList.swift */; };
 		80CC39722B4430BA009E0818 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC39712B4430BA009E0818 /* AppDelegate.swift */; };
 		80CC39742B4430BA009E0818 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC39732B4430BA009E0818 /* SceneDelegate.swift */; };
 		80CC39762B4430BA009E0818 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CC39752B4430BA009E0818 /* OnboardingViewController.swift */; };
@@ -100,6 +101,7 @@
 		80C16BF62B4FD3A400414D98 /* KFModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KFModifier.swift; sourceTree = "<group>"; };
 		80C16BF82B5159D700414D98 /* ViewMove.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMove.swift; sourceTree = "<group>"; };
 		80C629772B61349C00CBFF97 /* toDateAndString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = toDateAndString.swift; sourceTree = "<group>"; };
+		80C6297A2B61350900CBFF97 /* WorkSpaceList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkSpaceList.swift; sourceTree = "<group>"; };
 		80CC396E2B4430BA009E0818 /* BranchTalk.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BranchTalk.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		80CC39712B4430BA009E0818 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		80CC39732B4430BA009E0818 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -253,6 +255,14 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		80C629792B6134F700CBFF97 /* Entities */ = {
+			isa = PBXGroup;
+			children = (
+				80C6297A2B61350900CBFF97 /* WorkSpaceList.swift */,
+			);
+			path = Entities;
+			sourceTree = "<group>";
+		};
 		80CC39652B4430BA009E0818 = {
 			isa = PBXGroup;
 			children = (
@@ -304,6 +314,7 @@
 		80CC39862B443575009E0818 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				80C629792B6134F700CBFF97 /* Entities */,
 				80CC39A72B443FE0009E0818 /* APIKey.swift */,
 				800ED5052B45CD89001A7ECC /* NetworkManager.swift */,
 				800ED5072B45CFE8001A7ECC /* Router.swift */,
@@ -458,6 +469,7 @@
 				80F80CCD2B5E4F120077654A /* DmFooterView.swift in Sources */,
 				80802AA02B46E09E008F1723 /* HomeEmptyViewController.swift in Sources */,
 				80CC39762B4430BA009E0818 /* OnboardingViewController.swift in Sources */,
+				80C6297B2B61350900CBFF97 /* WorkSpaceList.swift in Sources */,
 				80F80CC92B5E4EF90077654A /* DmTableViewCell.swift in Sources */,
 				800A05572B5268F40010505A /* SideMenuViewController.swift in Sources */,
 				80F80CC62B5D5C760077654A /* ChannelFooterView.swift in Sources */,

--- a/BranchTalk/Extensions/toDateAndString.swift
+++ b/BranchTalk/Extensions/toDateAndString.swift
@@ -1,0 +1,24 @@
+//
+//  toDateAndString.swift
+//  BranchTalk
+//
+//  Created by 황인호 on 1/24/24.
+//
+
+import Foundation
+
+extension String {
+    func toDate() -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        return dateFormatter.date(from: self)
+    }
+    
+    func toFormattedString() -> String? {
+        guard let date = self.toDate() else { return nil }
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yy. MM. dd"
+        return dateFormatter.string(from: date)
+    }
+}

--- a/BranchTalk/Model/NetworkModel.swift
+++ b/BranchTalk/Model/NetworkModel.swift
@@ -40,23 +40,6 @@ struct TokenResponse: Decodable {
     let accessToken: String
 }
 
-struct GetWorkSpaceInfo: Decodable {
-    let workspaceID: Int
-    let description: String?
-    let name, thumbnail: String
-    let ownerID: Int
-    let createdAt: String
-    
-    enum CodingKeys: String, CodingKey {
-        case workspaceID = "workspace_id"
-        case name, description, thumbnail
-        case ownerID = "owner_id"
-        case createdAt
-    }
-}
-
-typealias GetWorkSpaceList = [GetWorkSpaceInfo]
-
 struct MyInfo: Decodable {
     let userID, sesacCoin: Int
     let email, nickname, createdAt: String

--- a/BranchTalk/Model/NetworkModel.swift
+++ b/BranchTalk/Model/NetworkModel.swift
@@ -40,16 +40,6 @@ struct TokenResponse: Decodable {
     let accessToken: String
 }
 
-struct MyInfo: Decodable {
-    let userID, sesacCoin: Int
-    let email, nickname, createdAt: String
-    let profileImage, phone, vendor: String?
-    
-    enum CodingKeys: String, CodingKey {
-        case userID = "user_id"
-        case email, nickname, createdAt, profileImage, phone, vendor, sesacCoin
-    }
-}
 
 struct GetChannel: Decodable, Hashable {
     let workspaceID, channelID, ownerID, `private`: Int
@@ -62,29 +52,6 @@ struct GetChannel: Decodable, Hashable {
         case ownerID = "owner_id"
         case name, description, createdAt
         case `private`
-    }
-}
-
-struct GetDmList: Decodable, Hashable {
-    let workspaceID, roomID: Int
-    let createdAt: String
-    let user: User
-    
-    enum CodingKeys: String, CodingKey {
-        case workspaceID = "workspace_id"
-        case roomID = "room_id"
-        case createdAt, user
-    }
-    
-}
-
-struct User: Decodable, Hashable {
-    let userID: Int
-    let email, nickname, profileImage: String
-    
-    enum CodingKeys: String, CodingKey {
-        case userID = "user_id"
-        case email, nickname, profileImage
     }
 }
 

--- a/BranchTalk/Network/Entities/GetDmList.swift
+++ b/BranchTalk/Network/Entities/GetDmList.swift
@@ -1,0 +1,41 @@
+//
+//  GetDMList.swift
+//  BranchTalk
+//
+//  Created by 황인호 on 1/24/24.
+//
+
+import Foundation
+
+struct GetDmList: Decodable, Hashable {
+    let workspaceID, roomID: Int
+    let createdAt: String
+    let user: User
+    
+    enum CodingKeys: String, CodingKey {
+        case workspaceID = "workspace_id"
+        case roomID = "room_id"
+        case createdAt, user
+    }
+    
+}
+
+struct User: Decodable, Hashable {
+    let userID: Int
+    let email, nickname, profileImage: String
+    
+    enum CodingKeys: String, CodingKey {
+        case userID = "user_id"
+        case email, nickname, profileImage
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.userID = try container.decode(Int.self, forKey: .userID)
+        self.email = try container.decode(String.self, forKey: .email)
+        self.nickname = try container.decode(String.self, forKey: .email)
+        let path = try container.decodeIfPresent(String.self, forKey: .profileImage)
+        self.profileImage = APIKey.baseURL + "/v1" + (path ?? "")
+    }
+    
+}

--- a/BranchTalk/Network/Entities/MyInfo.swift
+++ b/BranchTalk/Network/Entities/MyInfo.swift
@@ -1,0 +1,34 @@
+//
+//  MyInfo.swift
+//  BranchTalk
+//
+//  Created by 황인호 on 1/24/24.
+//
+
+import Foundation
+
+struct MyInfo: Decodable {
+    let userID, sesacCoin: Int
+    let email, nickname, createdAt: String
+    let profileImage, phone, vendor: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case userID = "user_id"
+        case email, nickname, createdAt, profileImage, phone, vendor, sesacCoin
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.userID = try container.decode(Int.self, forKey: .userID)
+        self.email = try container.decode(String.self, forKey: .email)
+        self.nickname = try container.decode(String.self, forKey: .nickname)
+        self.createdAt = try container.decode(String.self, forKey: .createdAt)
+        let image = try container.decodeIfPresent(String.self, forKey: .profileImage)
+        self.profileImage = APIKey.baseURL + "/v1" + (image ?? "")
+        self.phone = try container.decodeIfPresent(String.self, forKey: .phone)
+        self.vendor = try container.decodeIfPresent(String.self, forKey: .vendor)
+        self.sesacCoin = try container.decode(Int.self, forKey: .sesacCoin)
+    }
+    
+    
+}

--- a/BranchTalk/Network/Entities/WorkSpaceList.swift
+++ b/BranchTalk/Network/Entities/WorkSpaceList.swift
@@ -31,7 +31,6 @@ struct WorkSpaceList: Decodable {
         self.ownerID = try container.decode(Int.self, forKey: .ownerID)
         
         let serverDate = try container.decode(String.self, forKey: .createdAt)
-        let date = serverDate.toDate()
         let formattedDate = serverDate.toFormattedString()
         
         self.createdAt = formattedDate ?? ""

--- a/BranchTalk/Network/Entities/WorkSpaceList.swift
+++ b/BranchTalk/Network/Entities/WorkSpaceList.swift
@@ -1,0 +1,39 @@
+//
+//  WorkSpaceList.swift
+//  BranchTalk
+//
+//  Created by 황인호 on 1/24/24.
+//
+
+import Foundation
+
+struct WorkSpaceList: Decodable {
+    let workspaceID: Int
+    let description: String?
+    let name, thumbnail: String
+    let ownerID: Int
+    let createdAt: String
+    
+    enum CodingKeys: String, CodingKey {
+        case workspaceID = "workspace_id"
+        case name, description, thumbnail
+        case ownerID = "owner_id"
+        case createdAt
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.workspaceID = try container.decode(Int.self, forKey: .workspaceID)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        let path = try container.decode(String.self, forKey: .thumbnail)
+        self.thumbnail = APIKey.baseURL + "/v1" + path
+        self.ownerID = try container.decode(Int.self, forKey: .ownerID)
+        
+        let serverDate = try container.decode(String.self, forKey: .createdAt)
+        let date = serverDate.toDate()
+        let formattedDate = serverDate.toFormattedString()
+        
+        self.createdAt = formattedDate ?? ""
+    }
+}

--- a/BranchTalk/Network/Router.swift
+++ b/BranchTalk/Network/Router.swift
@@ -28,9 +28,9 @@ enum Router: URLRequestConvertible {
     private var method: HTTPMethod {
         switch self {
         case .kakaoLogin, .emailValidate, .register, .makeWorkSpace:
-               return .post
+            return .post
         case .refresh, .getWorkSpaceList, .getMyProfile, .getChannelList, .getDmList:
-               return .get
+            return .get
         }
     }
     
@@ -94,12 +94,12 @@ enum Router: URLRequestConvertible {
     
     func asURLRequest() throws -> URLRequest {
         let url = baseURL.appendingPathComponent(path)
-
+        
         var request = URLRequest(url: url)
         request.method = method
         request.headers = header
         
-//        print("🩵", request.headers)
+        print("🩵", request.headers)
         
         if case .refresh = self {
             return request
@@ -111,7 +111,7 @@ enum Router: URLRequestConvertible {
         default:
             let jsonData = try? JSONSerialization.data(withJSONObject: parameters)
             request.httpBody = jsonData
-            return request  
+            return request
         }
     }
 }
@@ -129,7 +129,7 @@ extension Router {
             ]
             return makeMultipartFormdata(params: param, with: "workSpace")
             
-        default: return MultipartFormData()
+        default: return multipartFormData
         }
     }
     

--- a/BranchTalk/View/Onboarding/LaunchViewController.swift
+++ b/BranchTalk/View/Onboarding/LaunchViewController.swift
@@ -35,7 +35,7 @@ final class LaunchViewController: BaseViewController {
     }
     
     private func goToMainView() {
-        NetworkManager.shared.request(type: GetWorkSpaceList.self, api: .getWorkSpaceList) { result in
+        NetworkManager.shared.request(type: [WorkSpaceList].self, api: .getWorkSpaceList) { result in
             print(result)
             switch result {
             case .success(let response):

--- a/BranchTalk/View/SocialLogin/SocialLoginViewModel.swift
+++ b/BranchTalk/View/SocialLogin/SocialLoginViewModel.swift
@@ -71,7 +71,7 @@ class SocialLoginViewModel {
     }
     
     func getWorkSpaceList() {
-        NetworkManager.shared.request(type: GetWorkSpaceList.self, api: Router.getWorkSpaceList) { result in
+        NetworkManager.shared.request(type: [WorkSpaceList].self, api: Router.getWorkSpaceList) { result in
             switch result {
             case .success(let response):
                 print(response.count)

--- a/BranchTalk/View/WorkSpace/CreateWorkSpace/CreateWorkSpaceViewController.swift
+++ b/BranchTalk/View/WorkSpace/CreateWorkSpace/CreateWorkSpaceViewController.swift
@@ -64,6 +64,7 @@ final class CreateWorkSpaceViewController: BaseViewController {
     
     private let viewModel = CreateWorkSpaceViewModel()
     
+    private var imageObservable = BehaviorSubject(value: Data())
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = Colors.BackgroundPrimary.CutsomColor
@@ -76,8 +77,8 @@ final class CreateWorkSpaceViewController: BaseViewController {
             createButtonTapped: completButton.rx.tap.asObservable(),
             nameInput: nameTextField.rx.text.orEmpty.asObservable(),
             descInput: descriptionTextField.rx.text.orEmpty.asObservable(),
-            image: Observable.just(((imageView.image?.jpegData(compressionQuality: 1) ?? UIImage(named: "workspace")?.jpegData(compressionQuality: 1))!))
-            )
+            image: imageObservable.asObservable()
+        )
         
         let output = viewModel.transform(input: input)
         
@@ -190,8 +191,9 @@ extension CreateWorkSpaceViewController: PHPickerViewControllerDelegate {
                       let image = image as? UIImage else { return }
                 
                 DispatchQueue.main.async {
-                    self.imageView.image = image
                     self.wordingImageView.image = nil
+                    self.imageView.image = image
+                    self.imageObservable.onNext(image.jpegData(compressionQuality: 0.1) ?? Data())
                 }
             }
         }

--- a/BranchTalk/View/WorkSpace/CreateWorkSpace/CreateWorkSpaceViewModel.swift
+++ b/BranchTalk/View/WorkSpace/CreateWorkSpace/CreateWorkSpaceViewModel.swift
@@ -28,7 +28,7 @@ class CreateWorkSpaceViewModel: ViewModelType {
     
     func transform(input: Input) -> Output {
         let completeButtonActivate = BehaviorRelay<Bool>(value: false)
-        let completeButtontTapped = PublishRelay<Bool>()
+        let completeButtonTapped = PublishRelay<Bool>()
         
         
         input.nameTextFieldInput
@@ -64,7 +64,7 @@ class CreateWorkSpaceViewModel: ViewModelType {
         
         return Output(
             nameTextFieldInput: completeButtonActivate,
-            createButtonTapped: completeButtontTapped
+            createButtonTapped: completeButtonTapped
         )
     }
     

--- a/BranchTalk/View/WorkSpace/Main/HomeInitial/Dm/DmTableViewCell.swift
+++ b/BranchTalk/View/WorkSpace/Main/HomeInitial/Dm/DmTableViewCell.swift
@@ -46,7 +46,7 @@ class DmTableViewCell: UITableViewCell {
     }
     
     func configure(imageURL: String, name: String) {
-        profileImage.kf.setImage(with: URL(string: APIKey.baseURL + "/v1" + imageURL))
+        profileImage.kf.setImage(with: URL(string: imageURL))
         dmName.text = name
     }
     

--- a/BranchTalk/View/WorkSpace/Main/HomeInitial/Dm/DmTableViewCell.swift
+++ b/BranchTalk/View/WorkSpace/Main/HomeInitial/Dm/DmTableViewCell.swift
@@ -46,7 +46,7 @@ class DmTableViewCell: UITableViewCell {
     }
     
     func configure(imageURL: String, name: String) {
-        profileImage.kf.setImage(with: URL(string: imageURL))
+        profileImage.kf.setImage(with: URL(string: imageURL), options: [.requestModifier(KFModifier.shared.modifier)])
         dmName.text = name
     }
     

--- a/BranchTalk/View/WorkSpace/Main/HomeInitial/HomeInitialViewController.swift
+++ b/BranchTalk/View/WorkSpace/Main/HomeInitial/HomeInitialViewController.swift
@@ -129,10 +129,10 @@ final class HomeInitialViewController: BaseViewController {
     
     
     private func getWorkSpaceList() {
-        NetworkManager.shared.request(type: GetWorkSpaceList.self, api: Router.getWorkSpaceList) { [weak self] result in
+        NetworkManager.shared.request(type: [WorkSpaceList].self, api: Router.getWorkSpaceList) { [weak self] result in
             switch result {
             case .success(let response):
-                let imageURL = APIKey.baseURL + "/v1" + response[0].thumbnail
+                let imageURL = response[0].thumbnail
                 self?.setCustomNav(title: response[0].name, image: imageURL)
                 print(imageURL)
             case .failure(let error):
@@ -145,8 +145,8 @@ final class HomeInitialViewController: BaseViewController {
         NetworkManager.shared.request(type: MyInfo.self, api: Router.getMyProfile) { result in
             switch result {
             case .success(let response):
-                let image = APIKey.baseURL + (response.profileImage ?? "")
-                self.setCustomProfile(image: image)
+                let image = response.profileImage
+                self.setCustomProfile(image: image ?? "")
                 print(image)
             case .failure(let error):
                 print(error)

--- a/BranchTalk/View/WorkSpace/Main/HomeInitial/HomeInitialViewController.swift
+++ b/BranchTalk/View/WorkSpace/Main/HomeInitial/HomeInitialViewController.swift
@@ -147,7 +147,6 @@ final class HomeInitialViewController: BaseViewController {
             case .success(let response):
                 let image = response.profileImage
                 self.setCustomProfile(image: image ?? "")
-                print(image)
             case .failure(let error):
                 print(error)
             }
@@ -156,7 +155,8 @@ final class HomeInitialViewController: BaseViewController {
     
     
     private func setCustomNav(title: String, image: String) {
-        navImageView.kf.setImage(with: URL(string: image))
+        let url = URL(string: image)
+        navImageView.kf.setImage(with: url, options: [.requestModifier(KFModifier.shared.modifier)])
         lazy var spaceImage = UIBarButtonItem(customView: navImageView)
         lazy var spaceName = UIBarButtonItem(title: title, style: .plain, target: self, action: #selector(spaceImageTapped))
         let spacer = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
@@ -171,7 +171,7 @@ final class HomeInitialViewController: BaseViewController {
     
     private func setCustomProfile(image: String) {
         let profileImage = UIBarButtonItem(customView: profileImageView)
-        profileImageView.kf.setImage(with: URL(string: image))
+        profileImageView.kf.setImage(with: URL(string: image), options: [.requestModifier(KFModifier.shared.modifier)])
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(profileImageTapped))
         profileImageView.isUserInteractionEnabled = true
         profileImageView.addGestureRecognizer(tapGestureRecognizer)
@@ -220,8 +220,6 @@ final class HomeInitialViewController: BaseViewController {
     }
     
     private func headerTapped() {
-        
-        var sectionSnapshot = NSDiffableDataSourceSectionSnapshot<Item>()
         
         if isExpandable {
             isExpandable = false

--- a/BranchTalk/View/WorkSpace/Main/SideMenu/SideMenuTableViewCell.swift
+++ b/BranchTalk/View/WorkSpace/Main/SideMenu/SideMenuTableViewCell.swift
@@ -71,13 +71,13 @@ class SideMenuTableViewCell: UITableViewCell {
         }
         
         dotButton.snp.makeConstraints { make in
-            make.trailing.centerY.equalToSuperview()
+            make.centerY.equalToSuperview()
             make.trailing.equalToSuperview().inset(16)
         }
     }
     
      func configure(image: String, text: String, secondText: String) {
-        spaceImage.kf.setImage(with: URL(string: image))
+        spaceImage.kf.setImage(with: URL(string: image), options: [.requestModifier(KFModifier.shared.modifier)])
         titleTextLabel.text = text
         secondTextLabel.text = secondText
     }

--- a/BranchTalk/View/WorkSpace/Main/SideMenu/SideMenuViewController.swift
+++ b/BranchTalk/View/WorkSpace/Main/SideMenu/SideMenuViewController.swift
@@ -19,7 +19,7 @@ class SideMenuViewController: BaseViewController {
         return view
     }()
     
-    private let appendWorkSpaceButton = {
+    private lazy var appendWorkSpaceButton = {
         let bt = UIButton()
         var configuration = UIButton.Configuration.plain()
         configuration.image = UIImage(named: "plus")
@@ -31,6 +31,7 @@ class SideMenuViewController: BaseViewController {
         attributedText.foregroundColor = Colors.TextSecondary.CutsomColor
         configuration.attributedTitle = attributedText
         bt.configuration = configuration
+        bt.addTarget(self, action: #selector(appendWorkSpaceButtonTapped), for: .touchUpInside)
         return bt
     }()
     
@@ -70,6 +71,11 @@ class SideMenuViewController: BaseViewController {
                 print(failure)
             }
         }
+    }
+    
+    @objc func appendWorkSpaceButtonTapped() {
+        let vc = CreateWorkSpaceViewController()
+        present(vc, animated: true)
     }
     
     override func setUI() {

--- a/BranchTalk/View/WorkSpace/Main/SideMenu/SideMenuViewController.swift
+++ b/BranchTalk/View/WorkSpace/Main/SideMenu/SideMenuViewController.swift
@@ -49,7 +49,7 @@ class SideMenuViewController: BaseViewController {
         return bt
     }()
     
-    private var workSpaceResult = [GetWorkSpaceInfo]()
+    private var workSpaceResult = [WorkSpaceList]()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -61,7 +61,7 @@ class SideMenuViewController: BaseViewController {
     }
     
     private func getWorkList() {
-        NetworkManager.shared.refreshRequest(type: [GetWorkSpaceInfo].self, api: .getWorkSpaceList) { result in
+        NetworkManager.shared.refreshRequest(type: [WorkSpaceList].self, api: .getWorkSpaceList) { result in
             switch result {
             case .success(let success):
                 self.workSpaceResult.append(contentsOf: success)

--- a/BranchTalk/View/WorkSpace/Main/SideMenu/SideMenuViewController.swift
+++ b/BranchTalk/View/WorkSpace/Main/SideMenu/SideMenuViewController.swift
@@ -109,14 +109,13 @@ class SideMenuViewController: BaseViewController {
 
 extension SideMenuViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        print(workSpaceResult.count)
         return workSpaceResult.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: SideMenuTableViewCell.identifier, for: indexPath) as? SideMenuTableViewCell else { return UITableViewCell() }
         
-        let imageURL = APIKey.baseURL + "/v1" + workSpaceResult[indexPath.row].thumbnail
+        let imageURL = workSpaceResult[indexPath.row].thumbnail
         
         cell.configure(image: imageURL, text: workSpaceResult[indexPath.row].name, secondText: workSpaceResult[indexPath.row].createdAt)
         


### PR DESCRIPTION
# 작업내용 
- 네트워크 구조체에 init구문 추가
- 이미지 업로드 하는 로직 수정

# 새로 배운 것
```swift
- multipartFormData로 변환이 필요해서 image에서 data로 변환하는 과정에서 문제가 생겼습니다.
- debug 메서드를 활용해서 이미지가 제대로 전달이 되는지 확인을 해봤습니다.
// 처음 전달하던 방식
image: Observable.just(imageView.image?.jpegData(compressionQuality: 0.1) ?? Data())

- just라는 오퍼레이터는 동작을 한번만 전달하기 때문에 뷰에 들어가자 마자 빈 이미지만 전달이 되고 끝나는 상황이 발생했습니다.
- 추후에 이미지뷰에 이미지를 추가하더라도 이벤트가 발생하지 않았습니다. 
2024-01-25 16:47:23.597: CreateWorkSpaceViewController.swift:80 (bind()) -> subscribed
2024-01-25 16:47:23.599: CreateWorkSpaceViewController.swift:80 (bind()) -> Event next(0 bytes)
2024-01-25 16:47:23.600: CreateWorkSpaceViewController.swift:80 (bind()) -> Event completed
2024-01-25 16:47:23.600: CreateWorkSpaceViewController.swift:80 (bind()) -> isDisposed

- BehaviorSubject로 초기값을 빈 데이터 값으로 받고 이미지를 선택했을 때 onnext로 이미지를 전달해 주고 해결했습니다.
2024-01-25 16:54:59.986: CreateWorkSpaceViewController.swift:80 (bind()) -> subscribed
2024-01-25 16:54:59.988: CreateWorkSpaceViewController.swift:80 (bind()) -> Event next(0 bytes)

2024-01-25 16:55:03.180: CreateWorkSpaceViewController.swift:80 (bind()) -> Event next(148294 bytes)
``` 